### PR TITLE
Renommage cohérent du champ modif_secret_groupe

### DIFF
--- a/customfilter/templatetags/customfilter.py
+++ b/customfilter/templatetags/customfilter.py
@@ -48,7 +48,7 @@ def get_ects():
 
 @register.assignment_tag
 def get_modifgroupe():
-    return Config.objects.get_config().modif_secretariat_groupe
+    return Config.objects.get_config().modif_secret_groupe
 
 @register.assignment_tag
 def get_classes():


### PR DESCRIPTION
Le fichier customfilter.py fait référence à la propriété "modif_secretariat_groupe", alors que celle-ci s'appelle en fait "modif_secret_groupe" dans le modèle. Ceci provoque la levée d'une exception lors de l'identification du secrétariat.