### PR TITLE
 Ajout d'une option "rémunération horaire"

### DIFF
--- a/administrateur/forms.py
+++ b/administrateur/forms.py
@@ -18,7 +18,7 @@ class ConfigForm(forms.ModelForm):
 	class Meta:
 		model = Config
 		fields=['nom_etablissement','app_mobile','modif_secret_col','modif_secret_groupe','modif_prof_col','default_modif_col',\
-		'modif_prof_groupe','default_modif_groupe','mathjax','ects','nom_adresse_etablissement','ville','academie']
+		'modif_prof_groupe','default_modif_groupe','mathjax','ects','nom_adresse_etablissement','ville','academie','remuneration_horaire']
 
 	def save(self):
 		Config.objects.all().delete()

--- a/colleur/views.py
+++ b/colleur/views.py
@@ -485,9 +485,24 @@ def decompte(request):
 		listeclasses=[]
 		for classe in classes:
 			nbcolles=[]
+			
+			tpstotal = 0
 			for mois in listemois:
-				nbcolles.append(Note.objects.filter(colleur=colleur,matiere__nom__iexact=matiere,classe=classe,date_colle__month=mois.month,date_colle__year=mois.year).aggregate(temps=Sum('matiere__temps')))
-			total=Note.objects.filter(colleur=colleur,matiere__nom__iexact=matiere,classe=classe).aggregate(temps=Sum('matiere__temps'))
+				tps = 0
+				lcolles = Note.objects.filter(colleur=colleur,matiere__nom__iexact=matiere,classe=classe,date_colle__month=mois.month,date_colle__year=mois.year).values_list('semaine__numero','jour','heure','matiere__temps').annotate(nombre=Count('eleve_id'))
+				for sem,jour,heure,matieretemps,nombre in lcolles:
+					print(matieretemps)
+					print(nombre)
+					if matieretemps == 20 and Config.objects.get_config().remuneration_horaire:
+						tps += matieretemps * 3
+					else:
+						tps += matieretemps * nombre 
+				ret = {}
+				ret['temps'] = tps
+				nbcolles.append(ret)
+				tpstotal += tps
+			total = {'temps': tpstotal}
+
 			listeclasses.append((classe,nbcolles,total))
 		listematieres.append((matiere,listeclasses,listemois))
 		listematieres.sort(key=lambda x:x[0])


### PR DESCRIPTION
L'option "rémunération horaire" permet, lorsqu'elle est activée, de décompter les colles de 20 minutes par élèves en heures pleines, qu'il y ai eu 3 élèves notés ou non.
Cette option permet ainsi de respecter la réglementation ( https://aphec.fr/spip.php?article366 ), mais peut être désactivée pour les établissements qui refusent ce mode de calcul.