### PR TITLE
Hauteur minimale pour le menu

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -98,7 +98,7 @@ ul.accueil
 	background: -ms-linear-gradient(top,  #323232,  #5bbeff);
 	color:white; /* couleur du texte */
 	text-shadow: 2px 2px 2px black; /* quelques ombres sur le texte */
-	height:40px;
+	min-height:40px;
 	margin:0px;
 }
 .accueil li, .accueil td


### PR DESCRIPTION
Si le nom de la matière est trop important, des éléments peuvent se chevaucher. Plus avec cette modification. 